### PR TITLE
ゴースト絶対パス指定での起動オプションに変える

### DIFF
--- a/Satolist2/Utility/SSPBootUtility.cs
+++ b/Satolist2/Utility/SSPBootUtility.cs
@@ -41,7 +41,7 @@ namespace Satolist2.Utility
 			startInfo.FileName = executablePath;
 			startInfo.WorkingDirectory = System.IO.Directory.GetParent(executablePath).FullName;
 			startInfo.UseShellExecute = true;
-			startInfo.Arguments = string.Format("/o nobootcheck /g {0}", DictionaryUtility.GetDirectoryName(ghostPath));
+			startInfo.Arguments = string.Format(@"/o nobootcheck /g ""{0}""", ghostPath.Replace('/','\\'));
 			Process.Start(startInfo);
 		}
 	}


### PR DESCRIPTION
同フォルダ名のゴーストが複数居る場合に、正確に指定ゴーストを起動できない問題を修正
https://ukadon.shillest.net/@salad/109594485892368587

※現行SSPはバックスラッシュ区切りでないとうまく認識しないのでちょっと細工した。